### PR TITLE
Add free edit mode and improve exclusion formatting

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -20,6 +20,7 @@ export const App: React.FC = () => {
     toggleAutoCalc,
     toggleArrowsGlobal,
     toggleCountFormat,
+    toggleFreeEdit,
     undo,
     redo,
     removeNode,
@@ -121,6 +122,7 @@ export const App: React.FC = () => {
         onToggleAutoCalc={toggleAutoCalc}
         onToggleArrows={toggleArrowsGlobal}
         onToggleCountFormat={toggleCountFormat}
+        onToggleFreeEdit={toggleFreeEdit}
         onUndo={undo}
         onRedo={redo}
         onExportSvg={() => {

--- a/src/export/svg.ts
+++ b/src/export/svg.ts
@@ -21,7 +21,7 @@ export function generateSvg(graph: GraphState, settings: AppSettings): string {
     const center = node.position.x;
     const halfWidth = BOX_WIDTH / 2;
     const top = node.position.y;
-    const bottom = top + computeNodeHeight(node, settings.countFormat);
+    const bottom = top + computeNodeHeight(node, settings.countFormat, { freeEdit: settings.freeEdit });
     minX = Math.min(minX, center - halfWidth - exclusionReach);
     maxX = Math.max(maxX, center + halfWidth + exclusionReach);
     maxBottom = Math.max(maxBottom, bottom);
@@ -61,7 +61,7 @@ export function generateSvg(graph: GraphState, settings: AppSettings): string {
     const childCenterX = centerX + child.position.x;
     const parentTopY = verticalOffset + parent.position.y;
     const childTopY = verticalOffset + child.position.y;
-    const parentHeight = computeNodeHeight(parent, settings.countFormat);
+    const parentHeight = computeNodeHeight(parent, settings.countFormat, { freeEdit: settings.freeEdit });
     const parentBottomY = parentTopY + parentHeight;
     const childTop = childTopY;
     const showArrow = settings.arrowsGlobal && interval.arrow;
@@ -127,21 +127,12 @@ export function generateSvg(graph: GraphState, settings: AppSettings): string {
       deltaX = (parentCenterX + childCenterX) / 2;
     }
 
-    if (interval.delta) {
-      const deltaY = deltaCenterY;
-      const label = interval.delta > 0 ? `Δ = +${interval.delta}` : `Δ = ${interval.delta}`;
-      svgParts.push(
-        `<g class="delta-badge"><rect x="${deltaX - 32}" y="${deltaY - 12}" width="64" height="24" rx="12" fill="#d92c2c" />` +
-          `<text x="${deltaX}" y="${deltaY + 4}" fill="#ffffff" font-size="12" font-weight="bold" text-anchor="middle">${label}</text></g>`
-      );
-    }
-
     if (!allowExclusion) {
       return;
     }
 
     const exclusion = interval.exclusion ?? { label: 'Excluded', total: null, reasons: [] };
-    const exclusionLines = getExclusionDisplayLines(exclusion, settings.countFormat);
+    const exclusionLines = getExclusionDisplayLines(exclusion, settings.countFormat, { freeEdit: settings.freeEdit });
     if (!exclusionLines.length) {
       return;
     }
@@ -149,7 +140,7 @@ export function generateSvg(graph: GraphState, settings: AppSettings): string {
     const isLeft = exclusionSide === 'left';
     const lineEndX = isLeft ? anchorX - EXCLUSION_OFFSET_X : anchorX + EXCLUSION_OFFSET_X;
     const boxX = isLeft ? lineEndX - EXCLUSION_WIDTH : lineEndX;
-    const exclusionHeight = computeExclusionHeight(exclusion, settings.countFormat);
+    const exclusionHeight = computeExclusionHeight(exclusion, settings.countFormat, { freeEdit: settings.freeEdit });
     const boxY = anchorY - exclusionHeight / 2;
     const exclusionStartY = boxY + exclusionHeight / 2 - (LINE_HEIGHT * exclusionLines.length) / 2 + 6;
     const lineTargetX = isLeft ? lineEndX : boxX;
@@ -163,7 +154,7 @@ export function generateSvg(graph: GraphState, settings: AppSettings): string {
     );
     exclusionLines.forEach((line, index) => {
       const dy = index === 0 ? 0 : LINE_HEIGHT;
-      const isCountLine = line.startsWith('N =') || line.startsWith('(n =') || line.startsWith('(N =');
+      const isCountLine = index === exclusionLines.length - 1;
       svgParts.push(
         `<tspan x="${boxX + EXCLUSION_WIDTH / 2}" dy="${dy}"${isCountLine ? ' font-weight="600"' : ''}>${escapeText(
           line
@@ -176,11 +167,11 @@ export function generateSvg(graph: GraphState, settings: AppSettings): string {
   nodesOrdered.forEach((node) => {
     const x = centerX + node.position.x - BOX_WIDTH / 2;
     const y = verticalOffset + node.position.y;
-    const nodeHeight = computeNodeHeight(node, settings.countFormat);
+    const nodeHeight = computeNodeHeight(node, settings.countFormat, { freeEdit: settings.freeEdit });
     svgParts.push(
       `<rect x="${x}" y="${y}" width="${BOX_WIDTH}" height="${nodeHeight}" rx="8" ry="8" fill="#ffffff" stroke="#111111" stroke-width="2" />`
     );
-    const nodeLines = getNodeDisplayLines(node, settings.countFormat);
+    const nodeLines = getNodeDisplayLines(node, settings.countFormat, { freeEdit: settings.freeEdit });
     const totalHeight = LINE_HEIGHT * nodeLines.length;
     const startY = y + nodeHeight / 2 - totalHeight / 2 + 6;
     svgParts.push(`<text x="${x + BOX_WIDTH / 2}" y="${startY}" fill="#111111" font-family="system-ui, sans-serif" font-size="16" text-anchor="middle">`);

--- a/src/model/types.ts
+++ b/src/model/types.ts
@@ -9,6 +9,7 @@ export interface BoxNode {
   column: number;
   autoLocked: boolean;
   childIds: NodeId[];
+  countOverride?: string | null;
 }
 
 export type ExclusionReasonKind = 'user' | 'auto';
@@ -18,12 +19,14 @@ export interface ExclusionReason {
   label: string;
   n: number | null;
   kind: ExclusionReasonKind;
+  countOverride?: string | null;
 }
 
 export interface ExclusionBox {
   label: string;
   total: number | null;
   reasons: ExclusionReason[];
+  totalOverride?: string | null;
 }
 
 export interface Interval {
@@ -48,6 +51,7 @@ export interface AppSettings {
   autoCalc: boolean;
   arrowsGlobal: boolean;
   countFormat: CountFormat;
+  freeEdit: boolean;
 }
 
 export interface PersistedProject {

--- a/src/state/useStore.ts
+++ b/src/state/useStore.ts
@@ -40,17 +40,23 @@ interface AppStore {
     addNodeBelow: (parentId: NodeId) => void;
     addBranchChild: (parentId: NodeId) => void;
     updateNodeText: (nodeId: NodeId, textLines: string[]) => void;
-    updateNodeCount: (nodeId: NodeId, value: number | null) => void;
+    updateNodeCount: (nodeId: NodeId, value: number | null, override?: string | null) => void;
     updateExclusionLabel: (intervalId: IntervalId, label: string) => void;
-    updateExclusionCount: (intervalId: IntervalId, value: number | null) => void;
+    updateExclusionCount: (intervalId: IntervalId, value: number | null, override?: string | null) => void;
     addExclusionReason: (intervalId: IntervalId) => void;
     updateExclusionReasonLabel: (intervalId: IntervalId, reasonId: string, label: string) => void;
-    updateExclusionReasonCount: (intervalId: IntervalId, reasonId: string, value: number | null) => void;
+    updateExclusionReasonCount: (
+      intervalId: IntervalId,
+      reasonId: string,
+      value: number | null,
+      override?: string | null
+    ) => void;
     removeExclusionReason: (intervalId: IntervalId, reasonId: string) => void;
     removeNode: (nodeId: NodeId) => void;
     toggleAutoCalc: () => void;
     toggleArrowsGlobal: () => void;
     toggleCountFormat: () => void;
+    toggleFreeEdit: () => void;
     toggleArrow: (intervalId: IntervalId) => void;
     selectById: (id: string | undefined) => void;
     navigateSelection: (direction: 'up' | 'down' | 'left' | 'right') => void;
@@ -66,6 +72,7 @@ const defaultSettings: AppSettings = {
   autoCalc: true,
   arrowsGlobal: true,
   countFormat: 'upper',
+  freeEdit: false,
 };
 
 const defaultGraph = recomputeGraph(createInitialGraph(), defaultSettings);
@@ -142,10 +149,10 @@ export const useAppStore = create<AppStore>()(
               };
             });
           },
-          updateNodeCount: (nodeId, value) => {
+          updateNodeCount: (nodeId, value, override) => {
             const prev = cloneSnapshot(get().graph, get().settings);
             set((state) => {
-              const updatedGraph = recomputeGraph(updateNodeCount(state.graph, nodeId, value), state.settings);
+              const updatedGraph = recomputeGraph(updateNodeCount(state.graph, nodeId, value, override), state.settings);
               return {
                 ...state,
                 graph: updatedGraph,
@@ -164,10 +171,13 @@ export const useAppStore = create<AppStore>()(
               };
             });
           },
-          updateExclusionCount: (intervalId, value) => {
+          updateExclusionCount: (intervalId, value, override) => {
             const prev = cloneSnapshot(get().graph, get().settings);
             set((state) => {
-              const updatedGraph = recomputeGraph(updateExclusionCount(state.graph, intervalId, value), state.settings);
+              const updatedGraph = recomputeGraph(
+                updateExclusionCount(state.graph, intervalId, value, override),
+                state.settings
+              );
               return {
                 ...state,
                 graph: updatedGraph,
@@ -191,11 +201,14 @@ export const useAppStore = create<AppStore>()(
               history: pushHistory(state.history, prev),
             }));
           },
-          updateExclusionReasonCount: (intervalId, reasonId, value) => {
+          updateExclusionReasonCount: (intervalId, reasonId, value, override) => {
             const prev = cloneSnapshot(get().graph, get().settings);
             set((state) => ({
               ...state,
-              graph: recomputeGraph(updateExclusionReasonCount(state.graph, intervalId, reasonId, value), state.settings),
+              graph: recomputeGraph(
+                updateExclusionReasonCount(state.graph, intervalId, reasonId, value, override),
+                state.settings
+              ),
               history: pushHistory(state.history, prev),
             }));
           },
@@ -244,6 +257,19 @@ export const useAppStore = create<AppStore>()(
             set((state) => {
               const nextFormat: CountFormat = state.settings.countFormat === 'upper' ? 'parenthetical' : 'upper';
               const nextSettings: AppSettings = { ...state.settings, countFormat: nextFormat };
+              const updatedGraph = recomputeGraph(state.graph, nextSettings);
+              return {
+                ...state,
+                settings: nextSettings,
+                graph: updatedGraph,
+                history: pushHistory(state.history, prev),
+              };
+            });
+          },
+          toggleFreeEdit: () => {
+            const prev = cloneSnapshot(get().graph, get().settings);
+            set((state) => {
+              const nextSettings: AppSettings = { ...state.settings, freeEdit: !state.settings.freeEdit };
               const updatedGraph = recomputeGraph(state.graph, nextSettings);
               return {
                 ...state,
@@ -350,6 +376,9 @@ export const useAppStore = create<AppStore>()(
           } satisfies AppSettings;
           if (!mergedSettings.countFormat) {
             mergedSettings.countFormat = 'upper';
+          }
+          if (typeof mergedSettings.freeEdit !== 'boolean') {
+            mergedSettings.freeEdit = false;
           }
           return {
             ...currentState,

--- a/src/tests/graph.test.ts
+++ b/src/tests/graph.test.ts
@@ -11,8 +11,8 @@ import {
 } from '../model/graph';
 import { AppSettings } from '../model/types';
 
-const autoSettings: AppSettings = { autoCalc: true, arrowsGlobal: true };
-const unlockedSettings: AppSettings = { autoCalc: false, arrowsGlobal: true };
+const autoSettings: AppSettings = { autoCalc: true, arrowsGlobal: true, countFormat: 'upper', freeEdit: false };
+const unlockedSettings: AppSettings = { autoCalc: false, arrowsGlobal: true, countFormat: 'upper', freeEdit: false };
 
 describe('graph recalculation', () => {
   it('keeps delta balanced when counts align', () => {

--- a/src/tests/navigation.test.ts
+++ b/src/tests/navigation.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { addNodeBelow, createInitialGraph, navigateSelection, recomputeGraph, setSelected } from '../model/graph';
 import { AppSettings } from '../model/types';
 
-const autoSettings: AppSettings = { autoCalc: true, arrowsGlobal: true };
+const autoSettings: AppSettings = { autoCalc: true, arrowsGlobal: true, countFormat: 'upper', freeEdit: false };
 
 describe('keyboard navigation helpers', () => {
   it('moves from node to child node when navigating down', () => {

--- a/src/ui/Toolbar.tsx
+++ b/src/ui/Toolbar.tsx
@@ -8,6 +8,7 @@ interface ToolbarProps {
   onToggleAutoCalc: () => void;
   onToggleArrows: () => void;
   onToggleCountFormat: () => void;
+  onToggleFreeEdit: () => void;
   onUndo: () => void;
   onRedo: () => void;
   onExportSvg: () => void;
@@ -23,6 +24,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
   onToggleAutoCalc,
   onToggleArrows,
   onToggleCountFormat,
+  onToggleFreeEdit,
   onUndo,
   onRedo,
   onExportSvg,
@@ -51,6 +53,9 @@ export const Toolbar: React.FC<ToolbarProps> = ({
         </button>
         <button type="button" onClick={onToggleCountFormat}>
           {settings.countFormat === 'upper' ? 'Show (n)' : 'Show N'}
+        </button>
+        <button type="button" onClick={onToggleFreeEdit}>
+          {settings.freeEdit ? 'Exit Free Edit' : 'Free Edit'}
         </button>
         <button type="button" onClick={onReset}>
           Reset


### PR DESCRIPTION
## Summary
- add a Free Edit toolbar toggle that lets users override box counts, disables deltas, and keeps layout sizing
- update exclusion rendering to use consistent count formatting and only surface the “Other” row when patients remain
- ensure exports omit delta badges and honor Free Edit overrides for SVG/PNG output

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68defc099f18832b9653c0177cbcd334