### PR TITLE
Fix phase text visibility in exports

### DIFF
--- a/src/export/svg.ts
+++ b/src/export/svg.ts
@@ -326,7 +326,7 @@ export function generateSvg(graph: GraphState, settings: AppSettings): string {
 
     svgParts.push(
       `<rect x="${phaseRailX}" y="${topY}" width="${PHASE_WIDTH}" height="${phaseHeight}" rx="8" ry="8" fill="#ffffff" stroke="#111111" stroke-width="2" />`,
-      `<text x="${textX}" y="${textY}" text-anchor="middle" font-family="system-ui, sans-serif" font-size="16" font-weight="600" transform="rotate(-90 ${textX} ${textY})">`
+      `<text x="${textX}" y="${textY}" text-anchor="middle" font-family="system-ui, sans-serif" font-size="16" font-weight="600" fill="#111111" transform="rotate(-90 ${textX} ${textY})">`
     );
     lines.forEach((line, index) => {
       const dy = index === 0 ? 0 : LINE_HEIGHT;


### PR DESCRIPTION
Ensure exported SVGs/PNGs explicitly set fill for phase
  labels so text renders outside the app.